### PR TITLE
Bump tewhatuora.hip-core version to 1.9.1

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -24,7 +24,7 @@ dependencies:
     version: 0.0.11
   tewhatuora.hip-core:
      uri: https://fhir-ig.digital.health.nz/HIP-FHIR-Common
-     version: 1.9.0
+     version: 1.9.1
      
   # there is a dependency on NZBase to get the extensions defined in there  
   fhir.org.nz.ig.base:


### PR DESCRIPTION
Bump the version of tewhatuora.hip-core to `1.9.1`, to fix the terminology binding error seen in UAT

@pat-ryan-health 