### PR TITLE
Bump hip-core to 1.9.2

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -24,7 +24,7 @@ dependencies:
     version: 0.0.11
   tewhatuora.hip-core:
      uri: https://fhir-ig-uat.digital.health.nz/HIP-FHIR-Common
-     version: 1.9.1
+     version: 1.9.2
      
   # there is a dependency on NZBase to get the extensions defined in there  
   fhir.org.nz.ig.base:


### PR DESCRIPTION
Update hip-core to 1.9.2, which has corrected the hip-core canonical url, which in turn will fix the incorrect terminology bindings seen on https://fhir-ig-uat.digital.health.nz/HPI/StructureDefinition-HpiLocation.html

For example, these are currently `https://fhir-ig.digital.health.nz/ValueSet-hpi-location-type-1.0.html` however this should be `https://fhir-ig.digital.health.nz/HIP-FHIR-Common/ValueSet-hpi-location-type-1.0.html` as per the below screenshot of a local build with this change

![image](https://github.com/user-attachments/assets/ed0dd142-3877-471f-8a75-7aecffd19c28)

@pat-ryan-health this should be the last change..